### PR TITLE
Update README.md to link to correct repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A comprehensive template for getting started with Context Engineering - the disc
 
 ```bash
 # 1. Clone this template
-git clone https://github.com/coleam00/gemini-context-engineering.git
+git clone https://github.com/Ashiq3/gemini-context-engineering.git
 cd gemini-context-engineering
 
 # 2. Set up your project rules (optional - template provided)


### PR DESCRIPTION
Line 11 of README.md still instructs to:
git clone https://github.com/coleam00/gemini-context-engineering.git

instead of:
git clone https://github.com/Ashiq3/gemini-context-engineering.git